### PR TITLE
enabled hexadecimal values for deviceID

### DIFF
--- a/Smartify/app/src/main/java/com/example/smartify/editdevice/EditDevicePresenter.java
+++ b/Smartify/app/src/main/java/com/example/smartify/editdevice/EditDevicePresenter.java
@@ -76,7 +76,7 @@ class EditDevicePresenter implements EditDeviceContract.UserActionsListener {
             mView.longitudeRequired();
             return false;
         }
-        if (!deviceId.matches("[0-9]+")){
+        if (!deviceId.matches("[a-z0-9]+")){
             mView.deviceIdInvalid();
             return false;
         }

--- a/Smartify/app/src/main/res/layout/content_device_edit.xml
+++ b/Smartify/app/src/main/res/layout/content_device_edit.xml
@@ -37,7 +37,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/device_id"
-            android:inputType="number"
+            android:inputType="text"
             android:maxLines="1"/>
 
     </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
The Particle photon device numbers are hexadecimal.  I wasn't able to specify my device ID because of this, so I changed the relevant code parts to eanbe this. 

